### PR TITLE
test of alternative replication

### DIFF
--- a/multidc/src/main/resources/application.conf
+++ b/multidc/src/main/resources/application.conf
@@ -91,3 +91,53 @@ cassandra-query-journal-multi-dc {
   log-queries = on
 }
 
+# eu-west specific replication settings
+# it is used by eu-central when reading notifications and events from eu-west
+
+cassandra-journal-multi-dc-eu-west = ${cassandra-journal-multi-dc} # include default settings
+cassandra-journal-multi-dc-eu-west {
+  
+  query-plugin = "cassandra-query-journal-multi-dc-eu-west"
+  
+  port = 9042
+  
+  contact-points = [
+    "localhost"
+  ]
+  
+  log-queries = on
+}
+
+cassandra-query-journal-multi-dc-eu-west = ${cassandra-query-journal-multi-dc} # include default settings
+cassandra-query-journal-multi-dc-eu-west {
+  
+  write-plugin = "cassandra-journal-multi-dc-eu-west"
+  
+  log-queries = on
+}
+
+
+# eu-central specific replication settings
+# it is used by eu-west when reading notifications and events from eu-central
+
+cassandra-journal-multi-dc-eu-central = ${cassandra-journal-multi-dc} # include default settings
+cassandra-journal-multi-dc-eu-central {
+  
+  query-plugin = "cassandra-query-journal-multi-dc-eu-central"
+  
+  port = 9043
+  
+  contact-points = [
+    "localhost"
+  ]
+  
+  log-queries = on
+}
+
+cassandra-query-journal-multi-dc-eu-central = ${cassandra-query-journal-multi-dc} # include default settings
+cassandra-query-journal-multi-dc-eu-central {
+  
+  write-plugin = "cassandra-journal-multi-dc-eu-central"
+  
+  log-queries = on
+}


### PR DESCRIPTION
I have tried the alternative replication strategy https://github.com/typesafehub/akka-commercial-addons/issues/122, which is based on that there is no replication across DCs by C* itself.

It was only a small change needed, see https://github.com/typesafehub/akka-commercial-addons/pull/152
It's far from trivial (for other people) to get this configuration right, so we should probably consider something that is easier to configure.

Note that this is also reading the notifications the same way. The ticket mentions that the notification table should be replicated by C*, but I think it has less operational complexity to not have a C* x-DC cluster at all if going down this route.

This is how I tested:

1. Start one default conf C* server, listening on port 9042
1. Start another C* server, listening on port 9043 (changed a few other conflicting ports also)
1. Note that the above C* servers are completely isolated, not a cluster
1. Start Akka node 2552: `sbt "multidc/runMain com.lightbend.multidc.ReplicatedEntityApp"`
that is running in dc: eu-west and events are written to C* 9042, replicated events are read from C* 9043
1. Start Akka node 2553: `sbt -Dakka.remote.netty.tcp.port=2553 -Dakka.cluster.multi-data-center.self-data-center=eu-central -Dcassandra-journal-multi-dc.port=9043 -Dakka.cluster.http.management.port=19553 -Dmultidc.port=8053 "multidc/runMain com.lightbend.multidc.ReplicatedEntityApp"`
that is running in dc: eu-central and events are written to C* 9043, replicated events are read from C* 9042

Try with browser at http://localhost:8080 and http://localhost:8053
see routes in `HttpApi`.

Then I also verified with cqlsh that things ended up in right place.
